### PR TITLE
Mazo update

### DIFF
--- a/docs/openapi/inventory/deck_by_id.yaml
+++ b/docs/openapi/inventory/deck_by_id.yaml
@@ -1,0 +1,105 @@
+put:
+  tags:
+    - Inventory
+  summary: Actualizar mazo de flota
+  description: Modifica el nombre o la formación de barcos de un mazo. Valida que los barcos estén en la zona de despliegue permitida (15x5).
+  operationId: updateDeck
+  security:
+    - bearerAuth: []
+  parameters:
+    - name: deckId
+      in: path
+      required: true
+      description: UUID del mazo a modificar
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            deckName:
+              type: string
+              minLength: 2
+              maxLength: 30
+              example: "Flota Renombrada"
+            shipIds:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                properties:
+                  userShipId:
+                    type: string
+                    format: uuid
+                  position:
+                    type: object
+                    properties:
+                      x: { type: integer, example: 5 }
+                      y: { type: integer, example: 2 }
+                  orientation:
+                    type: string
+                    enum: [N, S, E, W]
+                    example: "E"
+  responses:
+    '200':
+      description: Mazo actualizado con éxito
+      content:
+        application/json:
+          schema:
+            $ref: '../shared/schemas.yaml#/FleetDeck'
+    '400':
+      description: Error de validación o barcos fuera de los límites del puerto (Y > 4)
+      content:
+        application/json:
+          schema:
+            $ref: '../shared/schemas.yaml#/ValidationError'
+    '404':
+      description: Mazo no encontrado
+    '401':
+      description: No autorizado
+
+delete:
+  tags:
+    - Inventory
+  summary: Eliminar un mazo de flota
+  description: Borra un mazo. No se permitirá borrar si es el único mazo que le queda al usuario en su cuenta.
+  operationId: deleteDeck
+  security:
+    - bearerAuth: []
+  parameters:
+    - name: deckId
+      in: path
+      required: true
+      description: UUID del mazo a eliminar
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Mazo eliminado exitosamente
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "Mazo eliminado correctamente"
+    '400':
+      description: El usuario intenta borrar su único mazo
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "No puedes eliminar tu único mazo. Debes tener al menos una formación configurada."
+    '404':
+      description: Mazo no encontrado
+    '401':
+      description: No autorizado

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -38,6 +38,8 @@ paths:
     $ref: './inventory/decks.yaml'
   /api/inventory/decks/{deckId}/activate:
     $ref: './inventory/activate_deck.yaml'
+  /api/inventory/decks/{deckId}:
+    $ref: './inventory/deck_by_id.yaml'
   #matches
   /api/matches/history:
     $ref: './game/history.yaml'

--- a/src/modules/inventory/controllers/deckController.int.test.js
+++ b/src/modules/inventory/controllers/deckController.int.test.js
@@ -102,4 +102,19 @@ describe('DeckController Integration (Refactored)', () => {
         expect(res.status).toBe(400);
         expect(res.body.message).toContain('único mazo');
     });
+
+    it('POST /api/inventory/decks - Debe rechazar la creación si un barco no pertenece al usuario', async () => {
+        const fakeShipId = '11111111-1111-1111-1111-111111111111'; // UUID inventado
+        
+        const res = await request(app)
+            .post('/api/inventory/decks')
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                deckName: 'Mazo Hackeado',
+                shipIds: [{ userShipId: fakeShipId, position: { x: 0, y: 2 }, orientation: 'N' }]
+            });
+
+        expect(res.status).toBe(403);
+        expect(res.body.message).toContain('no te pertenecen');
+    });
 });

--- a/src/modules/inventory/controllers/deckController.int.test.js
+++ b/src/modules/inventory/controllers/deckController.int.test.js
@@ -47,4 +47,59 @@ describe('DeckController Integration (Refactored)', () => {
         expect(res.status).toBe(201);
         expect(res.body.deckName).toBe('Mazo Legal');
     });
+
+
+    it('PUT /api/inventory/decks/:deckId - Debe actualizar el nombre y la formación de un mazo existente', async () => {
+        const res = await request(app)
+            .put(`/api/inventory/decks/${setup.deck.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                deckName: 'Mazo Renombrado',
+                shipIds: [{ userShipId: setup.uShip.id, position: { x: 5, y: 3 }, orientation: 'E' }]
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.deckName).toBe('Mazo Renombrado');
+        expect(res.body.shipIds[0].orientation).toBe('E');
+        expect(res.body.shipIds[0].position.x).toBe(5);
+    });
+
+    it('PUT /api/inventory/decks/:deckId - Debe rechazar la actualización si la nueva formación sale del puerto', async () => {
+        const res = await request(app)
+            .put(`/api/inventory/decks/${setup.deck.id}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                shipIds: [{ userShipId: setup.uShip.id, position: { x: 5, y: 10 }, orientation: 'N' }]
+            });
+
+        expect(res.status).toBe(400);
+        expect(res.body.message).toContain('fuera de los límites');
+    });
+
+    it('DELETE /api/inventory/decks/:deckId - Debe permitir eliminar un mazo si el usuario tiene más de uno', async () => {
+        // Obtenemos los mazos actuales setup y el del 2o test
+        const getRes = await request(app)
+            .get('/api/inventory/decks')
+            .set('Authorization', `Bearer ${token}`);
+        
+        // Buscamos el ID del Mazo Legal pa borrarlo
+        const deckToDelete = getRes.body.find(d => d.deckName === 'Mazo Legal');
+
+        const res = await request(app)
+            .delete(`/api/inventory/decks/${deckToDelete.id}`)
+            .set('Authorization', `Bearer ${token}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body.message).toContain('eliminado correctamente');
+    });
+
+    it('DELETE /api/inventory/decks/:deckId - Debe rechazar la eliminación si es el único mazo que le queda al usuario', async () => {
+        // Como borramos el Mazo Legal en el test anterior, ahora solo le queda el Mazo Renombrado
+        const res = await request(app)
+            .delete(`/api/inventory/decks/${setup.deck.id}`)
+            .set('Authorization', `Bearer ${token}`);
+
+        expect(res.status).toBe(400);
+        expect(res.body.message).toContain('único mazo');
+    });
 });

--- a/src/modules/inventory/controllers/deckController.js
+++ b/src/modules/inventory/controllers/deckController.js
@@ -50,3 +50,58 @@ export const getMyDecks = async (req, res, next) => {
         next(error);
     }
 };
+
+/**
+ * Actualiza la formación de barcos o el nombre de un mazo
+ */
+export const updateDeck = async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+
+    try {
+        const { deckId } = req.params;
+        const { deckName, shipIds } = req.body;
+
+        // Si se están cambiando los barcos, validamos que estén en la zona 15x5
+        if (shipIds && !inventoryService.validarLimitesPuerto(shipIds)) {
+            return res.status(400).json({ message: 'Barcos fuera de los límites del puerto (15x5)' });
+        }
+
+        const mazoActualizado = await InventoryDao.updateDeck(deckId, req.user.id, {
+            deckName,
+            shipIds
+        });
+
+        if (!mazoActualizado) return res.status(404).json({ message: 'Mazo no encontrado' });
+
+        res.json(mazoActualizado);
+    } catch (error) {
+        next(error);
+    }
+};
+
+/**
+ * Elimina un mazo si no es el único que tiene el usuario
+ */
+export const deleteDeck = async (req, res, next) => {
+    try {
+        const { deckId } = req.params;
+        const userId = req.user.id;
+
+        const totalMazos = await InventoryDao.countUserDecks(userId);
+        
+        if (totalMazos <= 1) {
+            return res.status(400).json({ 
+                message: 'No puedes eliminar tu único mazo. Debes tener al menos una formación configurada.' 
+            });
+        }
+
+        const eliminado = await InventoryDao.deleteDeck(deckId, userId);
+        
+        if (!eliminado) return res.status(404).json({ message: 'Mazo no encontrado' });
+
+        res.json({ message: 'Mazo eliminado correctamente' });
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/modules/inventory/controllers/deckController.js
+++ b/src/modules/inventory/controllers/deckController.js
@@ -16,6 +16,11 @@ export const createDeck = async (req, res, next) => {
             return res.status(400).json({ message: 'Barcos fuera de los límites del puerto (15x5)' });
         }
 
+        const sonPropios = await inventoryService.verificarPropiedadBarcos(req.user.id, shipIds);
+        if (!sonPropios) {
+            return res.status(403).json({ message: 'Uno o más barcos no te pertenecen o no existen' });
+        }
+
         const nuevoMazo = await InventoryDao.createDeck({
             userId: req.user.id,
             deckName,
@@ -65,6 +70,11 @@ export const updateDeck = async (req, res, next) => {
         // Si se están cambiando los barcos, validamos que estén en la zona 15x5
         if (shipIds && !inventoryService.validarLimitesPuerto(shipIds)) {
             return res.status(400).json({ message: 'Barcos fuera de los límites del puerto (15x5)' });
+        }
+
+        const sonPropios = await inventoryService.verificarPropiedadBarcos(req.user.id, shipIds);
+        if (!sonPropios) {
+            return res.status(403).json({ message: 'Uno o más barcos no te pertenecen o no existen' });
         }
 
         const mazoActualizado = await InventoryDao.updateDeck(deckId, req.user.id, {

--- a/src/modules/inventory/dao/InventoryDao.js
+++ b/src/modules/inventory/dao/InventoryDao.js
@@ -181,6 +181,33 @@ class InventoryDao {
         });
         return userShip.ShipTemplate.baseMaxHp;
     }
+
+    /**
+     * Cuenta cuántos mazos tiene un usuario
+     */
+    async countUserDecks(userId) {
+        return await FleetDeck.count({ where: { userId } });
+    }
+
+    /**
+     * Actualiza los datos de un mazo (nombre o formación de barcos)
+     */
+    async updateDeck(deckId, userId, updateData) {
+        const [updatedRows, [updatedDeck]] = await FleetDeck.update(updateData, {
+            where: { id: deckId, userId },
+            returning: true
+        });
+        return updatedDeck;
+    }
+
+    /**
+     * Elimina un mazo específico
+     */
+    async deleteDeck(deckId, userId) {
+        return await FleetDeck.destroy({
+            where: { id: deckId, userId }
+        });
+    }
 }
 
 export default new InventoryDao();

--- a/src/modules/inventory/routes/inventoryRoutes.js
+++ b/src/modules/inventory/routes/inventoryRoutes.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 import { protect } from '../../../shared/middlewares/authMiddleware.js';
-import { createDeck, getMyDecks, setActiveDeck } from '../controllers/deckController.js';
+import { createDeck, getMyDecks, setActiveDeck, updateDeck, deleteDeck } from '../controllers/deckController.js';
 import { equipWeapon, getMyShips, removeWeaponFromShip, showAllWeapons } from '../controllers/inventoryController.js';
 
 const router = Router();
@@ -32,5 +32,18 @@ router.post('/decks', [
 router.patch('/decks/:deckId/activate', [
     param('deckId').isUUID().withMessage('ID inválido')
 ], setActiveDeck);
+
+// ACTUALIZAR Mazo (Barcos o nombre)
+router.put('/decks/:deckId', [
+    param('deckId').isUUID().withMessage('ID de mazo inválido'),
+    body('deckName').optional().isLength({ min: 2, max: 30 }),
+    body('shipIds').optional().isArray({ min: 1 })
+], updateDeck);
+
+// ELIMINAR Mazo
+router.delete('/decks/:deckId', [
+    param('deckId').isUUID().withMessage('ID de mazo inválido')
+], deleteDeck);
+
 
 export default router;

--- a/src/modules/inventory/routes/inventoryRoutes.js
+++ b/src/modules/inventory/routes/inventoryRoutes.js
@@ -33,14 +33,12 @@ router.patch('/decks/:deckId/activate', [
     param('deckId').isUUID().withMessage('ID inválido')
 ], setActiveDeck);
 
-// ACTUALIZAR Mazo (Barcos o nombre)
 router.put('/decks/:deckId', [
     param('deckId').isUUID().withMessage('ID de mazo inválido'),
     body('deckName').optional().isLength({ min: 2, max: 30 }),
     body('shipIds').optional().isArray({ min: 1 })
 ], updateDeck);
 
-// ELIMINAR Mazo
 router.delete('/decks/:deckId', [
     param('deckId').isUUID().withMessage('ID de mazo inválido')
 ], deleteDeck);

--- a/src/modules/inventory/services/inventoryService.js
+++ b/src/modules/inventory/services/inventoryService.js
@@ -20,6 +20,19 @@ export const validarLimitesPuerto = (formation) => {
 };
 
 /**
+ * Verifica que todos los barcos enviados en la formación pertenezcan al usuario.
+ * @param {string} userId - UUID del usuario
+ * @param {Array} formation - Array de barcos recibidos en el payload
+ * @returns {Promise<boolean>} True si todos le pertenecen, false si hay intrusos
+ */
+export const verificarPropiedadBarcos = async (userId, formation) => {
+    const misBarcos = await InventoryDao.findUserShips(userId);
+    const misBarcosIds = misBarcos.map(b => b.id);
+
+    return formation.every(ship => misBarcosIds.includes(ship.userShipId));
+};
+
+/**
  * Actualiza el equipamiento de un barco
  * @param {Object} ship 
  * @param {string} weaponSlug 


### PR DESCRIPTION
### Resumen
He implementado los 2 endpoints faltantes de flota y he arreglado el exploit de insertar barcos en mazos que detectamos.

### Detalles
- Se han añadido los endpoints faltantes para modificar (`PUT`) y borrar (`DELETE`) mazos de la flota.
- Se ha implementado una regla de negocio que impide a un usuario eliminar su último y único mazo.
-  Se ha implementado el método `verificarPropiedadBarcos`. Ahora el backend verifica estrictamente que los UUIDs de los barcos enviados al crear o editar un mazo pertenecen realmente al inventario del jugador que realiza la petición.
- Se ha actualizado la documentación de OpenAPI (Swagger) reflejando las nuevas rutas (`deck_by_id.yaml`).

### Testing
- Se han añadido nuevos bloques de tests de integración en `deckController.int.test.js` para validar las nuevas adiciones.

Resolves #20 #51
