### PR TITLE
Barcos hundidos

### DIFF
--- a/src/modules/engine/sockets/combat/cannon.js
+++ b/src/modules/engine/sockets/combat/cannon.js
@@ -4,7 +4,7 @@
 import EngineDao from '../../dao/EngineDao.js';
 import MatchDao from '../../../game/dao/MatchDao.js';
 import * as combatService from '../../services/combatService.js';
-import { matchService } from '../../../game/index.js';
+import { matchService, statusService } from '../../../game/index.js';
 import { engineService } from '../../services/index.js';
 
 export const handleCannonAttack = async (io, socket, data) => {
@@ -18,6 +18,12 @@ export const handleCannonAttack = async (io, socket, data) => {
         const targetTraducido =  matchService.traducirPosicionTablero(target, jugador.side);
         if (!partida || !barco || !jugador) {
             throw new Error('No se han encontrado las entidades necesarias');
+        }
+        if (partida.status !== 'PLAYING') {
+            throw new Error('La partida no está activa');
+        }
+        if (barco.isSunk) {
+            throw new Error('El barco está hundido y no puede realizar acciones');
         }
         const cannon = barco.CombatWeapons?.find(w => w.type === 'CANNON');
         if (!cannon) {
@@ -60,6 +66,15 @@ export const handleCannonAttack = async (io, socket, data) => {
             
             await EngineDao.registerHit(objetivo.id, newHp, objetivo.hitCells || [], isSunk);
             targetHp = newHp;
+
+            // Verificar si todos esta hundidos para acabar la partida
+            if (isSunk) {
+                const derrotado = await statusService.verificarDerrotaJugador(matchId, objetivo.playerId);
+                if (derrotado) {
+                    await statusService.registrarVictoria(matchId, userId); // Gana el atacante
+                    io.to(matchId).emit('match:finished', { winnerId: userId, reason: 'elimination' });
+                }
+            }
         }
 
         const nuevaMunicion = jugador.ammoCurrent - cannon.apCost;

--- a/src/modules/engine/sockets/combat/mine.js
+++ b/src/modules/engine/sockets/combat/mine.js
@@ -29,6 +29,14 @@ export const handleMineDrop = async (io, socket, data) => {
             throw new Error('Munición insuficiente para mina');
         }
 
+        if (partida.status !== 'PLAYING') {
+            throw new Error('La partida no está activa');
+        }
+        
+        if (barco.isSunk) {
+            throw new Error('El barco está hundido y no puede realizar acciones');
+        }
+
         //Calcular celdas ocupadas del barco
         const tamanoBase = await EngineDao.getShipSize(barco.id);
         const tamanoEfectivo = engineService.calculartamanoEfectivo(tamanoBase.width, tamanoBase.height, barco.orientation);

--- a/src/modules/engine/sockets/combat/torpedo.js
+++ b/src/modules/engine/sockets/combat/torpedo.js
@@ -30,6 +30,14 @@ export const handleTorpedoLaunch = async (io, socket, data) => {
             throw new Error('Munición insuficiente para torpedo');
         }
 
+        if (partida.status !== 'PLAYING') {
+            throw new Error('La partida no está activa');
+        }
+        
+        if (barco.isSunk) {
+            throw new Error('El barco está hundido y no puede realizar acciones');
+        }
+
         const tamanoBase = await EngineDao.getShipSize(barco.id);
         const tamanoReal = engineService.calculartamanoEfectivo(tamanoBase.width, tamanoBase.height, barco.orientation);
         const frente = combatService.obtenerFrente(barco.x, barco.y, barco.orientation, tamanoReal.effectiveWidth, tamanoReal.effectiveHeight);

--- a/src/modules/engine/sockets/movement.js
+++ b/src/modules/engine/sockets/movement.js
@@ -4,7 +4,7 @@
 import MatchDao from '../../game/dao/MatchDao.js';
 import EngineDao from '../dao/EngineDao.js';
 import { combatService, engineService, Projectile } from '../index.js';
-import { matchService } from '../../game/index.js';
+import { matchService, statusService } from '../../game/index.js';
 import ProjectileDao from '../dao/ProjectileDao.js';
 
 export const registerMovementHandlers = (io, socket) => {
@@ -34,6 +34,14 @@ export const registerMovementHandlers = (io, socket) => {
             if (jugador.fuelReserve < costes.TRASLACION) {
                 throw new Error('Recursos insuficientes');
             }
+            
+            if (partida.status !== 'PLAYING') {
+                throw new Error('La partida no está activa');
+            }
+            if (barco.isSunk) {
+                throw new Error('El barco está hundido y no puede realizar acciones');
+            }
+
             const nuevaPos = engineService.calcularTraslacion({ x: barco.x, y: barco.y }, dirTraducida);
 
             //Calcular tamaño del barco y las casillas que ocupan
@@ -62,6 +70,17 @@ export const registerMovementHandlers = (io, socket) => {
                     proyectilColisionado: proyectilColisionado.id,
                     newHp
                 });
+
+                // Verificacamos muerte
+                if (isSunk) {
+                    const derrotado = await statusService.verificarDerrotaJugador(matchId, userId);
+                    if (derrotado) {
+                        const ganador = partida.MatchPlayers.find(p => p.userId !== userId);
+                        await statusService.registrarVictoria(matchId, ganador.userId);
+                        io.to(matchId).emit('match:finished', { winnerId: ganador.userId, reason: 'elimination' });
+                    }
+                }
+
             }
             // Calculamos los nuevos recursos
             const nuevoFuel = jugador.fuelReserve - costes.TRASLACION;
@@ -115,6 +134,13 @@ export const registerMovementHandlers = (io, socket) => {
             if (degrees !== 90 && degrees !== -90) {
                 throw new Error('Rotación inválida. Solo 90 o -90 grados.');
             }
+
+            if (partida.status !== 'PLAYING') {
+                throw new Error('La partida no está activa');
+            }
+            if (barco.isSunk) {
+                throw new Error('El barco está hundido y no puede realizar acciones');
+            }
             
             const nuevaOrientacion = engineService.calcularRotacion(barco.orientation, degrees);
 
@@ -146,6 +172,16 @@ export const registerMovementHandlers = (io, socket) => {
                     proyectilColisionado: proyectilColisionado.id,
                     newHp
                 });
+
+                // Verificacamos muerte
+                if (isSunk) {
+                    const derrotado = await statusService.verificarDerrotaJugador(matchId, userId);
+                    if (derrotado) {
+                        const ganador = partida.MatchPlayers.find(p => p.userId !== userId);
+                        await statusService.registrarVictoria(matchId, ganador.userId);
+                        io.to(matchId).emit('match:finished', { winnerId: ganador.userId, reason: 'elimination' });
+                    }
+                }
             }
 
             // Calculamos los nuevos recursos

--- a/src/modules/game/sockets/turn.js
+++ b/src/modules/game/sockets/turn.js
@@ -138,6 +138,17 @@ export const registerTurnHandlers = (io, socket) => {
                                 newHp
                             });
 
+                            // Verificacamos fin de partida si un proyectil hunde un barco
+                            if (isSunk) {
+                                const derrotado = await statusService.verificarDerrotaJugador(matchId, barco.playerId);
+                                if (derrotado) {
+                                    // Gana el que no sea el dueño del barco destruido
+                                    const ganador = partida.MatchPlayers.find(p => p.userId !== barco.playerId);
+                                    await statusService.registrarVictoria(matchId, ganador.userId);
+                                    io.to(matchId).emit('match:finished', { winnerId: ganador.userId, reason: 'elimination' });
+                                }
+                            }
+
                             await matchService.notificarVisionSala(io, matchId);
                             break; 
                         }


### PR DESCRIPTION
### Resumen
He implementado las verificaciones de los barcos hundidos para que no puedan realizar acciones y que al hundir todos los barcos del oponente se acabe la partida.

### Detalles
- **Hundidos no pueden realizar acciones:** Se verifica que el barco no esté hundido al intentar: Mover, Rotar, usar Cañon, usar Mina, usar Torpedo
- **Fin de partida:** Se verifica que la partida debe acabar por hundimiento de todos los barcos cuando:
  - Un barco se mueve sobre una casilla con un proyectil
  - Un barco rota sobre una casilla con un proyectil
  - Un barco es impactado por cañon
  - Un proyectil colisiona al final de turno sobre un barco

Resolves #58 
Resolves #60
